### PR TITLE
Skip tests using boto3 if AWS credentials are not found

### DIFF
--- a/tests/word_tokenizer/test_kytea_tokenizer.py
+++ b/tests/word_tokenizer/test_kytea_tokenizer.py
@@ -58,6 +58,10 @@ def test_postagging_with_kytea():
 
 
 def test_kytea_with_s3_model():
+    import os
+    if os.getenv("AWS_ACCESS_KEY_ID") is None:
+        pytest.skip("AWS credentials not found")
+
     try:
         import boto3
         del boto3

--- a/tests/word_tokenizer/test_sentencepiece_tokenizer.py
+++ b/tests/word_tokenizer/test_sentencepiece_tokenizer.py
@@ -18,6 +18,10 @@ def test_word_tokenize_with_sentencepiece():
 
 
 def test_sentencepiece_with_s3_model():
+    import os
+    if os.getenv("AWS_ACCESS_KEY_ID") is None:
+        pytest.skip("AWS credentials not found")
+
     try:
         import boto3
         del boto3


### PR DESCRIPTION
ref. https://github.com/himkt/konoha/pull/107#discussion_r466123751

CI is not able to access AWS credentials if the PR comes from forked repo.