### PR TITLE
Run pre-compile regular expressions before tokenization

### DIFF
--- a/konoha/sentence_tokenizer.py
+++ b/konoha/sentence_tokenizer.py
@@ -10,8 +10,8 @@ class SentenceTokenizer:
     PERIOD_SPECIAL = "__PERIOD__"
 
     PATTERNS = [
-        r"（.*?）",
-        r"「.*?」",
+        re.compile(r"（.*?）"),
+        re.compile(r"「.*?」"),
     ]
 
     @staticmethod
@@ -30,7 +30,6 @@ class SentenceTokenizer:
         """
 
         for pattern in SentenceTokenizer.PATTERNS:
-            pattern = re.compile(pattern)  # type: ignore
             document = re.sub(pattern, self.conv_period, document)
 
         result = []


### PR DESCRIPTION
@hppRC show that a sentence tokenizer could be faster by using pre-compiled regexp objects.
In this PR, I modified `sentence_tokenizer.py` based on the suggestion by @hppRC.

The following benchmark confirms the certain performance gain.

```bash
> time poetry run python benchmark.py
mean: 8.069960498809815sec with std 0.2850634093193728
poetry run python benchmark.py  41.41s user 0.34s system 102% cpu 40.931 total

> git checkout performance/sentence-tokenization
Switched to branch 'performance/sentence-tokenization'

> time poetry run python benchmark.py
mean: 7.03724775314331sec with std 0.1719490321050499
poetry run python benchmark.py  36.23s user 0.35s system 102% cpu 35.836 total
```

- benchmark script:

<details>

```python
from konoha import SentenceTokenizer

import time
import numpy


DOCUMENT = """
私は猫である。にゃお。\r\n
にゃにゃ
わんわん。にゃーにゃー。
"""


def main():
    tokenizer = SentenceTokenizer()
    expected = ["私は猫である。", "にゃお。", "にゃにゃ", "わんわん。", "にゃーにゃー。"]
    for _ in range(1_000_000):
        assert expected == tokenizer.tokenize(DOCUMENT)


if __name__ == "__main__":
    elapsed_times = []

    for _ in range(5):
        launch = time.time()
        main()
        finish = time.time()
        elapsed_times.append(finish - launch)

    print(f"mean: {numpy.mean(elapsed_times)}sec with std {numpy.std(elapsed_times)}")
```

</details>