### PR TITLE
Update max-line-length for linters and remove poetry-dynamic-versioning.substitution

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,10 +55,6 @@ docs = ["sphinx", "sphinx_rtd_theme"]
 enable = true
 style = "pep440"
 
-[tool.poetry-dynamic-versioning.substitution]
-files = ["konoha/__version__.py"]
-style = "pep440"
-
 [build-system]
 requires = ["poetry>=1.0.2", "poetry-dynamic-versioning"]
 build-backend = "poetry.masonry.api"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.black]
-line-length = 99
+line-length = 119
 
 [tool.poetry]
 name = "konoha"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,8 @@
 [black]
-max-line-length = 99
+max-line-length = 119
 
 [isort]
 force_single_line=true
+
+[flake8]
+max-line-length = 119


### PR DESCRIPTION
- c4a98b5 b3c6048: Allow us to write a line up to 119 chars in one line
- 00deb3f: Remove `poetry-dynamic-versioning.substitution`, which is not used