### PR TITLE
Update API module: change endpoint path and upgrade Ubuntu to 20.04

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -8,11 +8,11 @@ on:
 
 jobs:
   build-tiny:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.6, 3.7]
+        python-version: [3.6, 3.7, 3.8]
 
     steps:
     - uses: actions/checkout@v1
@@ -34,56 +34,14 @@ jobs:
     - name: Test with pytest
       run: |
         pip install pytest
-        pytest
+        pytest --ignore=tests/api
 
   build-all:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.6, 3.7]
-
-    steps:
-    - uses: actions/checkout@v1
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
-      with:
-        python-version: ${{ matrix.python-version }}
-    - name: Install tokenizers
-      run: |
-        sudo apt update -y
-        sudo apt install mecab libmecab-dev mecab-ipadic-utf8
-        cd /tmp
-        wget http://www.phontron.com/kytea/download/kytea-0.4.7.tar.gz && \
-        tar zxvf kytea-0.4.7.tar.gz && cd kytea-0.4.7 && \
-        wget https://patch-diff.githubusercontent.com/raw/neubig/kytea/pull/24.patch && \
-        git apply ./24.patch && ./configure && \
-        sudo make && sudo make install && sudo ldconfig -v
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install .[all]
-    - name: Lint with flake8
-      run: |
-        pip install flake8
-        # stop the build if there are Python syntax errors or undefined names
-        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
-    - name: Test with pytest
-      env:
-        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      run: |
-        pip install pytest
-        pytest
-
-  build-all-with-integrations:
-    runs-on: ubuntu-18.04
-    strategy:
-      max-parallel: 4
-      matrix:
-        python-version: [3.6, 3.7]
+        python-version: [3.6, 3.7, 3.8]
 
     steps:
     - uses: actions/checkout@v1

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ You can also batch tokenize by passing `texts: ["１つ目の入力", "２つ目
 Send a request using `curl` on you terminal.
 
 ```json
-$ curl localhost:8000/api/tokenize -X POST -H "Content-Type: application/json" \
+$ curl localhost:8000/api/v1/tokenize -X POST -H "Content-Type: application/json" \
     -d '{"tokenizer": "mecab", "text": "これはペンです"}'
 
 {

--- a/README.md
+++ b/README.md
@@ -89,13 +89,6 @@ I recommend you to install konoha by `pip install 'konoha[all]'` or `pip install
 - Install konoha with a specific tokenizer and AllenNLP integration: `pip install 'konoha[(tokenizer_name),allennlp]`.
 - Install konoha with a specific tokenzier and remote file support: `pip install 'konoha[(tokenizer_name),remote]'`
 
-** Attention!! **
-
-Currently, installing konoha with all tokenizers on Python3.8 fails.
-This failure happens since we can't install nagisa on Python3.8. (https://github.com/taishi-i/nagisa/issues/24)
-This problem is caused by DyNet dependency problem. (https://github.com/clab/dynet/issues/1616)
-DyNet doesn't provide wheel for Python3.8 and building DyNet from source doesn't work due to the dependency issue of DyNet.
-
 If you want to install konoha with a tokenizer, please install konoha with a specific tokenizer
 (e.g. `konoha[mecab]`, `konoha[sudachi]`, ...etc) or install tokenizers individually.
 

--- a/docker/app/Dockerfile
+++ b/docker/app/Dockerfile
@@ -1,5 +1,6 @@
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 
+ENV DEBIAN_FRONTEND "noninteractive"
 ENV LANG "ja_JP.UTF-8"
 ENV PYTHONIOENCODING "utf-8"
 

--- a/docker/app/Dockerfile
+++ b/docker/app/Dockerfile
@@ -32,8 +32,11 @@ COPY ./tests ./tests
 COPY ./konoha ./konoha
 COPY ./pyproject.toml ./pyproject.toml
 COPY ./poetry.lock ./poetry.lock
+COPY ./README.md ./README.md
+COPY ./libexec ./libexec
 
 RUN pip3 install -U pip
-RUN pip3 install .[all]
+RUN pip3 install poetry
+RUN poetry install --no-dev -E all
 
-CMD ["uvicorn", "konoha.api.server:app", "--reload", "--host", "0.0.0.0", "--port", "8000"]
+CMD ["poetry", "run", "uvicorn", "libexec.api:app", "--reload", "--host", "0.0.0.0", "--port", "8000"]

--- a/konoha/api/server.py
+++ b/konoha/api/server.py
@@ -1,7 +1,10 @@
 from fastapi import FastAPI
 
-from konoha.api import tokenizers
+from konoha.api.v1 import tokenization
 
-app = FastAPI()
-app.tokenizers = {}  # type: ignore
-app.include_router(tokenizers.router)
+
+def create_app() -> FastAPI:
+    app = FastAPI()
+    app.tokenizers = {}  # type: ignore
+    app.include_router(tokenization.router)
+    return app

--- a/konoha/api/v1/tokenization.py
+++ b/konoha/api/v1/tokenization.py
@@ -22,7 +22,7 @@ router = APIRouter()
 logger = logging.getLogger(__file__)
 
 
-@router.post("/api/tokenize")
+@router.post("/api/v1/tokenize")
 def tokenize(params: TokenizeParameter, request: Request):
     if params.text is not None:
         texts = [params.text]

--- a/libexec/api.py
+++ b/libexec/api.py
@@ -1,0 +1,4 @@
+from konoha.api.server import create_app
+
+
+app = create_app()

--- a/tests/api/v1/test_tokenization.py
+++ b/tests/api/v1/test_tokenization.py
@@ -1,0 +1,31 @@
+from typing import Dict
+from fastapi.testclient import TestClient
+
+import pytest
+
+from konoha.api.server import create_app
+
+
+app = create_app()
+client = TestClient(app)
+
+
+@pytest.mark.parametrize(
+    "tokenizer_params", [
+        {"tokenizer": "mecab"},
+        {"tokenizer": "sudachi", "mode": "A"},
+        {"tokenizer": "sudachi", "mode": "B"},
+        {"tokenizer": "sudachi", "mode": "C"},
+        {"tokenizer": "sentencepiece", "model_path": "data/model.knm"},
+        {"tokenizer": "kytea", "model_path": "data/model.knm"},
+        {"tokenizer": "character"},
+        {"tokenizer": "nagisa"},
+        {"tokenizer": "janome"},
+    ]
+)
+def test_tokenization(tokenizer_params: Dict):
+    headers = {"Content-Type": "application/json"}
+    params = dict(tokenizer_params, text="私は猫")
+    response = client.post("/api/v1/tokenize", headers=headers, json=params)
+    assert response.status_code == 200
+    assert "tokens" in response.json()


### PR DESCRIPTION
- eb729b0 **breaking change**: changes a path to tokenization API
- cf2b258 upgrades Ubuntu from 18.04 to 20.04
- ac82176 511117b update api stuff
- c2398d5 adds tests
- 2e3df8d updates Dockerfile
- 0fd6aea cleans up GitHub Actions configuration
- 8a97686 updates README to remove a note for nagisa installation