### PR TITLE
Feature/remote tokenization

### DIFF
--- a/konoha/api/v1/tokenization.py
+++ b/konoha/api/v1/tokenization.py
@@ -11,11 +11,11 @@ from konoha import WordTokenizer
 
 
 class TokenizeParameter(BaseModel):
+    tokenizer: str
     model_path: Optional[str] = None
     text: Optional[str] = None
     texts: Optional[List[str]] = None
-    tokenizer: str
-    mode: str = "A"
+    mode: Optional[str] = "A"
 
 
 router = APIRouter()
@@ -31,7 +31,11 @@ def tokenize(params: TokenizeParameter, request: Request):
     else:
         raise HTTPException(status_code=400, detail="text or texts is required.")
 
-    mode = params.mode.lower()
+    if isinstance(params.mode, str):
+        mode = params.mode.lower()  # type: Optional[str]
+    else:
+        mode = None
+
     model_path = (
         "data/model.spm" if params.tokenizer.lower() == "sentencepiece" else None
     )  # NOQA

--- a/poetry.lock
+++ b/poetry.lock
@@ -173,7 +173,7 @@ name = "certifi"
 version = "2020.12.5"
 description = "Python package for providing Mozilla's CA Bundle."
 category = "main"
-optional = true
+optional = false
 python-versions = "*"
 
 [[package]]
@@ -192,7 +192,7 @@ name = "chardet"
 version = "4.0.0"
 description = "Universal encoding detector for Python 2 and 3"
 category = "main"
-optional = true
+optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [[package]]
@@ -354,7 +354,7 @@ name = "idna"
 version = "2.10"
 description = "Internationalized Domain Names in Applications (IDNA)"
 category = "main"
-optional = true
+optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [[package]]
@@ -909,7 +909,7 @@ name = "requests"
 version = "2.25.1"
 description = "Python HTTP for Humans."
 category = "main"
-optional = true
+optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [package.dependencies]
@@ -1392,7 +1392,7 @@ name = "urllib3"
 version = "1.26.3"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 category = "main"
-optional = true
+optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, <4"
 
 [package.extras]
@@ -1484,7 +1484,7 @@ sudachi = ["sudachipy", "sudachidict-core"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.6.1"
-content-hash = "feab4644488852d19d4e82282b47e05b3859397d3a7ad1ca68a15120437f4169"
+content-hash = "df489f99f29754dc220a97c7b914a07f9a99b56fe3ef637890dc6281441dcbe2"
 
 [metadata.files]
 alabaster = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ sphinx_rtd_theme = {version = "^0.4.3", optional = true}
 nagisa = {version = "^0.2.7", optional = true}
 overrides = {version = "^3.0.0"}
 importlib-metadata = "^3.7.0"
+requests = "^2.25.1"
 
 [tool.poetry.dev-dependencies]
 python-language-server = "^0.31.2"

--- a/tests/word_tokenizer/test_remote_tokenizer.py
+++ b/tests/word_tokenizer/test_remote_tokenizer.py
@@ -1,0 +1,19 @@
+from unittest import mock
+
+from konoha import WordTokenizer
+
+
+def test_word_tokenize_with_remote_host():
+    tokenizer = WordTokenizer(endpoint="localhost:8000/api/v1/tokenize", tokenizer="mecab")
+    dummy_tokens = [{"surface": "テスト", "part_of_speech": "名詞"}]
+
+    with mock.patch("konoha.WordTokenizer._tokenize_with_remote_host", return_value=dummy_tokens) as mock_obj:
+        tokenizer.tokenize("猫は可愛い")
+        assert mock_obj.call_args[1]["endpoint"] == "http://localhost:8000/api/v1/tokenize"
+        assert mock_obj.call_args[1]["headers"] == {"Content-Type": "application/json"}
+        assert mock_obj.call_args[1]["payload"] == {
+            "text": "猫は可愛い",
+            "tokenizer": "mecab",
+            "model_path": None,
+            "mode": None,
+        }


### PR DESCRIPTION
This PR introduces a new feature to use konoha without installing any tokenizers on local machine.
If `endpoint` is specified in an initializer of `WordTokenizer`,
`tokenizer.tokenize` sends a request to the given endpoint for getting a tokenization result.

```python
from konoha import WordTokenizer


tokenizer = WordTokenizer(
    tokenizer="mecab",
    endpoint="http://localhost:8000/api/v1/tokenize"
)
print(tokenizer.tokenize("猫はかわいい"))
```