### PR TITLE
Return detailed information of token in konoha API

### DIFF
--- a/konoha/__init__.py
+++ b/konoha/__init__.py
@@ -1,7 +1,7 @@
 """__init__.py."""
-from konoha.sentence_tokenizer import SentenceTokenizer  # NOQA
-from konoha.word_tokenizer import WordTokenizer  # NOQA
 from importlib_metadata import version
 
+from konoha.sentence_tokenizer import SentenceTokenizer  # NOQA
+from konoha.word_tokenizer import WordTokenizer  # NOQA
 
 __version__ = version("konoha")

--- a/konoha/data/token.py
+++ b/konoha/data/token.py
@@ -1,5 +1,5 @@
 """Token class."""
-from typing import Optional
+from typing import Dict, List, Optional
 
 
 class Token:
@@ -120,6 +120,22 @@ class Token:
         return self._normalized_form
 
     @property
+    def feature_names(_) -> List[str]:
+        return [
+            "surface",
+            "postag",
+            "postag2",
+            "postag3",
+            "postag4",
+            "inflection",
+            "conjugation",
+            "base_form",
+            "yomi",
+            "pron",
+            "normalized_form",
+        ]
+
+    @property
     def feature(self) -> str:
         feature = []
         if self.postag is not None:
@@ -143,3 +159,10 @@ class Token:
         if self.normalized_form is not None:
             feature.append(self.normalized_form)
         return ",".join(feature)
+
+    @classmethod
+    def from_dict(cls, dict: dict):
+        return cls(**dict)
+
+    def dict(self) -> Dict:
+        return {f: getattr(self, f) for f in self.feature_names}

--- a/konoha/data/token.py
+++ b/konoha/data/token.py
@@ -1,5 +1,7 @@
 """Token class."""
-from typing import Dict, List, Optional
+from typing import Dict
+from typing import List
+from typing import Optional
 
 
 class Token:

--- a/konoha/integrations/_allennlp.py
+++ b/konoha/integrations/_allennlp.py
@@ -1,4 +1,3 @@
-
 class Token:
     ...
 

--- a/konoha/integrations/allennlp.py
+++ b/konoha/integrations/allennlp.py
@@ -50,14 +50,7 @@ class KonohaTokenizer(Tokenizer):
     @overrides
     def tokenize(self, text: str) -> List[Token]:
         konoha_tokens = self._tokenizer.tokenize(text)
-        tokens = [
-            Token(
-                text=token.surface,
-                lemma_=token.base_form,
-                pos_=token.postag,
-            )
-            for token in konoha_tokens
-        ]
+        tokens = [Token(text=token.surface, lemma_=token.base_form, pos_=token.postag,) for token in konoha_tokens]
 
         for start_token in self._start_tokens:
             tokens.insert(0, Token(start_token, 0))

--- a/konoha/sentence_tokenizer.py
+++ b/konoha/sentence_tokenizer.py
@@ -16,9 +16,7 @@ class SentenceTokenizer:
 
     @staticmethod
     def conv_period(item) -> str:
-        return item.group(0).replace(
-            SentenceTokenizer.PERIOD, SentenceTokenizer.PERIOD_SPECIAL
-        )
+        return item.group(0).replace(SentenceTokenizer.PERIOD, SentenceTokenizer.PERIOD_SPECIAL)
 
     def tokenize(self, document) -> List[str]:
         """

--- a/konoha/word_tokenizer.py
+++ b/konoha/word_tokenizer.py
@@ -1,6 +1,7 @@
 """Word Level Tokenizer."""
 import warnings
-from typing import Any, Dict
+from typing import Any
+from typing import Dict
 from typing import List
 from typing import Optional
 

--- a/konoha/word_tokenizer.py
+++ b/konoha/word_tokenizer.py
@@ -119,7 +119,7 @@ class WordTokenizer:
 
             tokens = []
             for token_param in token_params:
-                token = Token(surface=token_param["surface"], postag=token_param["part_of_speech"])
+                token = Token.from_dict(token_param)
                 tokens.append(token)
 
             return tokens

--- a/konoha/word_tokenizer.py
+++ b/konoha/word_tokenizer.py
@@ -65,9 +65,7 @@ class WordTokenizer:
             if self._model_path is None:
                 raise ValueError("`model_path` must be specified for sentencepiece.")
 
-            self._tokenizer = word_tokenizers.SentencepieceTokenizer(
-                model_path=self._model_path,
-            )
+            self._tokenizer = word_tokenizers.SentencepieceTokenizer(model_path=self._model_path,)
 
         if self._tokenizer_name == "mecab":
             self._tokenizer = word_tokenizers.MeCabTokenizer(
@@ -79,22 +77,17 @@ class WordTokenizer:
 
         if self._tokenizer_name == "janome":
             self._tokenizer = word_tokenizers.JanomeTokenizer(
-                user_dictionary_path=self._user_dictionary_path,
-                with_postag=self._with_postag,
+                user_dictionary_path=self._user_dictionary_path, with_postag=self._with_postag,
             )
 
         if self._tokenizer_name == "sudachi":
             if self._mode is None:
                 raise ValueError("`mode` must be specified for sudachi.")
 
-            self._tokenizer = word_tokenizers.SudachiTokenizer(
-                mode=self._mode, with_postag=self._with_postag,
-            )
+            self._tokenizer = word_tokenizers.SudachiTokenizer(mode=self._mode, with_postag=self._with_postag,)
 
         if self._tokenizer_name == "nagisa":
-            self._tokenizer = word_tokenizers.NagisaTokenizer(
-                with_postag=self._with_postag,
-            )
+            self._tokenizer = word_tokenizers.NagisaTokenizer(with_postag=self._with_postag,)
 
     def tokenize(self, text: str) -> List[Token]:
         """Tokenize input text"""
@@ -111,11 +104,7 @@ class WordTokenizer:
                 "text": text,
             }
             headers = {"Content-Type": "application/json"}
-            token_params = self._tokenize_with_remote_host(
-                endpoint=endpoint,
-                payload=payload,
-                headers=headers,
-            )
+            token_params = self._tokenize_with_remote_host(endpoint=endpoint, payload=payload, headers=headers,)
 
             tokens = []
             for token_param in token_params:
@@ -128,16 +117,8 @@ class WordTokenizer:
             return self._tokenizer.tokenize(text)
 
     @staticmethod
-    def _tokenize_with_remote_host(
-        endpoint: str,
-        payload: Dict,
-        headers: Dict,
-    ) -> List[Dict]:
-        return requests.post(
-            endpoint,
-            json=payload,
-            headers=headers,
-        ).json()["tokens"][0]
+    def _tokenize_with_remote_host(endpoint: str, payload: Dict, headers: Dict,) -> List[Dict]:
+        return requests.post(endpoint, json=payload, headers=headers,).json()["tokens"][0]
 
     @property
     def tokenizer(self) -> BaseTokenizer:

--- a/konoha/word_tokenizers/janome_tokenizer.py
+++ b/konoha/word_tokenizers/janome_tokenizer.py
@@ -8,9 +8,7 @@ from konoha.word_tokenizers.tokenizer import BaseTokenizer
 class JanomeTokenizer(BaseTokenizer):
     """Wrapper class for Janome."""
 
-    def __init__(
-        self, user_dictionary_path: Optional[str] = None, with_postag: bool = False
-    ) -> None:
+    def __init__(self, user_dictionary_path: Optional[str] = None, with_postag: bool = False) -> None:
         try:
             from janome.tokenizer import Tokenizer
         except ImportError:

--- a/konoha/word_tokenizers/kytea_tokenizer.py
+++ b/konoha/word_tokenizers/kytea_tokenizer.py
@@ -8,13 +8,9 @@ from konoha.word_tokenizers.tokenizer import BaseTokenizer
 class KyTeaTokenizer(BaseTokenizer):
     """Wrapper class forKyTea"""
 
-    def __init__(
-        self, with_postag: bool = False, model_path: Optional[str] = None, **kwargs
-    ) -> None:
+    def __init__(self, with_postag: bool = False, model_path: Optional[str] = None, **kwargs) -> None:
 
-        super(KyTeaTokenizer, self).__init__(
-            name="kytea", with_postag=with_postag, model_path=model_path
-        )
+        super(KyTeaTokenizer, self).__init__(name="kytea", with_postag=with_postag, model_path=model_path)
         try:
             import Mykytea
         except ImportError:
@@ -43,9 +39,7 @@ class KyTeaTokenizer(BaseTokenizer):
                 # FIXME If input contains a character "/",
                 #       KyTea outputs "//補助記号/・",
                 #       which breaks the simple logic elem.split("/")
-                pron, postag, surface = map(
-                    lambda e: e[::-1], elem[::-1].split("/", maxsplit=2)
-                )
+                pron, postag, surface = map(lambda e: e[::-1], elem[::-1].split("/", maxsplit=2))
                 surface = surface.replace("<SPACE>", " ")
                 tokens.append(Token(surface=surface, postag=postag, pron=pron))
 

--- a/konoha/word_tokenizers/mecab_tokenizer.py
+++ b/konoha/word_tokenizers/mecab_tokenizer.py
@@ -7,16 +7,7 @@ from konoha.word_tokenizers.tokenizer import BaseTokenizer
 
 def parse_feature_for_ipadic(elem) -> Token:
     surface, feature = elem.split("\t")
-    (
-        postag,
-        postag2,
-        postag3,
-        postag4,
-        inflection,
-        conjugation,
-        base_form,
-        *other,
-    ) = feature.split(",")
+    (postag, postag2, postag3, postag4, inflection, conjugation, base_form, *other,) = feature.split(",")
 
     # For words not in a dictionary
     if len(other) == 2:

--- a/konoha/word_tokenizers/nagisa_tokenizer.py
+++ b/konoha/word_tokenizers/nagisa_tokenizer.py
@@ -8,15 +8,12 @@ from konoha.word_tokenizers.tokenizer import BaseTokenizer
 class NagisaTokenizer(BaseTokenizer):
     """Wrapper class for Nagisa"""
 
-    def __init__(
-        self, with_postag: bool = False, **kwargs
-    ) -> None:
+    def __init__(self, with_postag: bool = False, **kwargs) -> None:
 
-        super(NagisaTokenizer, self).__init__(
-            name="nagisa", with_postag=with_postag
-        )
+        super(NagisaTokenizer, self).__init__(name="nagisa", with_postag=with_postag)
         try:
             import nagisa
+
             self._tokenizer = nagisa
         except ImportError:
             msg = "Importing nagisa failed for some reason."
@@ -27,7 +24,9 @@ class NagisaTokenizer(BaseTokenizer):
         response = self._tokenizer.tagging(text)
 
         if self._with_postag:
-            tokens = [Token(surface=surface, postag=postag) for (surface, postag) in zip(response.words, response.postags)]
+            tokens = [
+                Token(surface=surface, postag=postag) for (surface, postag) in zip(response.words, response.postags)
+            ]
         else:
             tokens = [Token(surface=surface) for surface in response.words]
 

--- a/konoha/word_tokenizers/sudachi_tokenizer.py
+++ b/konoha/word_tokenizers/sudachi_tokenizer.py
@@ -59,14 +59,7 @@ class SudachiTokenizer(BaseTokenizer):
         for token in self._tokenizer.tokenize(text, self._mode):
             surface = token.surface()
             if self._with_postag:
-                (
-                    postag,
-                    postag2,
-                    postag3,
-                    postag4,
-                    inflection,
-                    conjugation,
-                ) = token.part_of_speech()
+                (postag, postag2, postag3, postag4, inflection, conjugation,) = token.part_of_speech()
                 base_form = token.dictionary_form()
                 normalized_form = token.normalized_form()
                 yomi = token.reading_form()

--- a/tests/api/v1/test_tokenization.py
+++ b/tests/api/v1/test_tokenization.py
@@ -16,7 +16,7 @@ client = TestClient(app)
         {"tokenizer": "sudachi", "mode": "A"},
         {"tokenizer": "sudachi", "mode": "B"},
         {"tokenizer": "sudachi", "mode": "C"},
-        {"tokenizer": "sentencepiece", "model_path": "data/model.knm"},
+        {"tokenizer": "sentencepiece", "model_path": "data/model.spm"},
         {"tokenizer": "kytea", "model_path": "data/model.knm"},
         {"tokenizer": "character"},
         {"tokenizer": "nagisa"},

--- a/tests/word_tokenizer/test_remote_tokenizer.py
+++ b/tests/word_tokenizer/test_remote_tokenizer.py
@@ -5,7 +5,7 @@ from konoha import WordTokenizer
 
 def test_word_tokenize_with_remote_host():
     tokenizer = WordTokenizer(endpoint="localhost:8000/api/v1/tokenize", tokenizer="mecab")
-    dummy_tokens = [{"surface": "テスト", "part_of_speech": "名詞"}]
+    dummy_tokens = [{"surface": "テスト", "postag": "名詞"}]
 
     with mock.patch("konoha.WordTokenizer._tokenize_with_remote_host", return_value=dummy_tokens) as mock_obj:
         tokenizer.tokenize("猫は可愛い")


### PR DESCRIPTION
This PR modifies the API server to contain rich token information in a response.

### Example

> % curl localhost:8000/api/v1/tokenize -X POST -H "Content-Type: application/json" -d '{"tokenizer": "sudachi", "text": "自然言語処理", "with_postag": true}'| jq

```json
{
  "tokens": [
    [
      {
        "surface": "自然",
        "postag": "名詞",
        "postag2": "普通名詞",
        "postag3": "一般",
        "postag4": "*",
        "inflection": "*",
        "conjugation": "*",
        "base_form": "自然",
        "yomi": "シゼン",
        "pron": null,
        "normalized_form": "自然"
      },
      {
        "surface": "言語",
        "postag": "名詞",
        "postag2": "普通名詞",
        "postag3": "一般",
        "postag4": "*",
        "inflection": "*",
        "conjugation": "*",
        "base_form": "言語",
        "yomi": "ゲンゴ",
        "pron": null,
        "normalized_form": "言語"
      },
      {
        "surface": "処理",
        "postag": "名詞",
        "postag2": "普通名詞",
        "postag3": "サ変可能",
        "postag4": "*",
        "inflection": "*",
        "conjugation": "*",
        "base_form": "処理",
        "yomi": "ショリ",
        "pron": null,
        "normalized_form": "処理"
      }
    ]
  ]
}
```