### PR TITLE
Support all options available for WordTokenizer in API server

### DIFF
--- a/konoha/word_tokenizer.py
+++ b/konoha/word_tokenizer.py
@@ -100,12 +100,15 @@ class WordTokenizer:
 
             payload = {
                 "tokenizer": self._tokenizer_name,
+                "with_postag": self._with_postag,
+                "user_dictionary_path": self._user_dictionary_path,
                 "model_path": self._model_path,
                 "mode": self._mode,
                 "text": text,
+                "dictionary_format": self._dictionary_format,
             }
             headers = {"Content-Type": "application/json"}
-            token_params = self._tokenize_with_remote_host(endpoint=endpoint, payload=payload, headers=headers,)
+            token_params = self._tokenize_with_remote_host(endpoint=endpoint, payload=payload, headers=headers)
 
             tokens = []
             for token_param in token_params:

--- a/konoha/word_tokenizer.py
+++ b/konoha/word_tokenizer.py
@@ -102,6 +102,7 @@ class WordTokenizer:
                 "tokenizer": self._tokenizer_name,
                 "with_postag": self._with_postag,
                 "user_dictionary_path": self._user_dictionary_path,
+                "system_dictionary_path": self._system_dictionary_path,
                 "model_path": self._model_path,
                 "mode": self._mode,
                 "text": text,

--- a/tests/api/v1/test_tokenization.py
+++ b/tests/api/v1/test_tokenization.py
@@ -13,6 +13,8 @@ client = TestClient(app)
 @pytest.mark.parametrize(
     "tokenizer_params", [
         {"tokenizer": "mecab"},
+        {"tokenizer": "mecab", "with_postag": True},
+        {"tokenizer": "mecab", "system_dictionary_path": "s3://konoha-demo/mecab/ipadic"},
         {"tokenizer": "sudachi", "mode": "A"},
         {"tokenizer": "sudachi", "mode": "B"},
         {"tokenizer": "sudachi", "mode": "C"},

--- a/tests/word_tokenizer/test_remote_tokenizer.py
+++ b/tests/word_tokenizer/test_remote_tokenizer.py
@@ -14,6 +14,10 @@ def test_word_tokenize_with_remote_host():
         assert mock_obj.call_args[1]["payload"] == {
             "text": "猫は可愛い",
             "tokenizer": "mecab",
+            "system_dictionary_path": None,
+            "user_dictionary_path": None,
             "model_path": None,
             "mode": None,
+            "dictionary_format": None,
+            "with_postag": False,
         }


### PR DESCRIPTION
For #134.

This PR introduces support for options `with_postag`, `user_dictionary`, and `dictionary_format` in API mode.