### PR TITLE
Use async methods to avoid resource competition

### DIFF
--- a/konoha/api/v1/batch_tokenization.py
+++ b/konoha/api/v1/batch_tokenization.py
@@ -31,7 +31,7 @@ def generate_cache_key(params):
 
 
 @router.post("/api/v1/batch_tokenize")
-def batch_tokenize(params: TokenizeParameter, request: Request):
+async def batch_tokenize(params: TokenizeParameter, request: Request):
     if params.texts is None:
         raise HTTPException(status_code=400, detail="texts is required.")
 

--- a/konoha/api/v1/tokenization.py
+++ b/konoha/api/v1/tokenization.py
@@ -31,7 +31,7 @@ def generate_cache_key(params):
 
 
 @router.post("/api/v1/tokenize")
-def tokenize(params: TokenizeParameter, request: Request):
+async def tokenize(params: TokenizeParameter, request: Request):
     if params.texts is not None:
         message = (
             "A parameter `texts` is now unacceptable for /api/v1/tokenize."


### PR DESCRIPTION
I found that sometimes konoha api failed to tokenize when handling multiple accesses.
This may be caused by resource competition because of the cached tokenizer shared with each access. 

By using async methods, this problem will be resolved since each access are scheduled by event loop and not executed simultaneously.