### PR TITLE
Configurable sentence tokenizer

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,29 @@ print(tokenizer.tokenize(sentence))
 # => ['私は猫だ。', '名前なんてものはない。', 'だが，「かわいい。それで十分だろう」。']
 ```
 
+You can change symbols for a sentence splitter and bracket expression.
+
+1. sentence splitter
+
+```python
+sentence = "私は猫だ。名前なんてものはない．だが，「かわいい。それで十分だろう」。"
+
+tokenizer = SentenceTokenizer(period="．")
+print(tokenizer.tokenize(sentence))
+# => ['私は猫だ。名前なんてものはない．', 'だが，「かわいい。それで十分だろう」。']
+```
+
+2. bracket expression
+
+```python
+sentence = "私は猫だ。名前なんてものはない。だが，『かわいい。それで十分だろう』。"
+
+tokenizer = SentenceTokenizer()
+print(tokenizer.tokenize(sentence))
+# => ['私は猫だ。', '名前なんてものはない。', 'だが，『かわいい。それで十分だろう』。']
+```
+
+
 ## Test
 
 ```

--- a/konoha/sentence_tokenizer.py
+++ b/konoha/sentence_tokenizer.py
@@ -1,5 +1,8 @@
 import re
 from typing import List
+from typing import Match
+from typing import Optional
+from typing import Pattern
 
 
 class SentenceTokenizer:
@@ -12,12 +15,20 @@ class SentenceTokenizer:
         re.compile(r"「.*?」"),
     ]
 
-    @staticmethod
-    def conv_period(item) -> str:
-        return item.group(0).replace(SentenceTokenizer.PERIOD, SentenceTokenizer.PERIOD_SPECIAL)
+    def __init__(
+        self,
+        period: Optional[str] = None,
+        patterns: Optional[List[Pattern[str]]] = None,
+    ) -> None:
 
-    def tokenize(self, document) -> List[str]:
-        for pattern in SentenceTokenizer.PATTERNS:
+        self._period = period or self.PERIOD
+        self._patterns = patterns or self.PATTERNS
+
+    def conv_period(self, item: Match) -> str:
+        return item.group(0).replace(self._period, SentenceTokenizer.PERIOD_SPECIAL)
+
+    def tokenize(self, document: str) -> List[str]:
+        for pattern in self._patterns:
             document = re.sub(pattern, self.conv_period, document)
 
         result = []
@@ -25,7 +36,7 @@ class SentenceTokenizer:
             line = line.rstrip()
             line = line.replace("\n", "")
             line = line.replace("\r", "")
-            line = line.replace("。", "。\n")
+            line = line.replace(f"{self._period}", f"{self._period}\n")
             sentences = line.split("\n")
 
             for sentence in sentences:
@@ -33,8 +44,7 @@ class SentenceTokenizer:
                     continue
 
                 period_special = SentenceTokenizer.PERIOD_SPECIAL
-                period = SentenceTokenizer.PERIOD
-                sentence = sentence.replace(period_special, period)
+                sentence = sentence.replace(period_special, self._period)
                 result.append(sentence)
 
         return result

--- a/tests/test_sentence_tokenizer.py
+++ b/tests/test_sentence_tokenizer.py
@@ -1,3 +1,5 @@
+import re
+
 from konoha.sentence_tokenizer import SentenceTokenizer
 
 DOCUMENT1 = """
@@ -20,6 +22,14 @@ DOCUMENT3 = """
 
 DOCUMENT4 = """
 わんわん。「にゃ？」(にゃー）わんわん。「わおーん。」（犬より。）
+"""
+
+DOCUMENT5 = """
+わんわん。「にゃ？」(にゃー）わんわん。『わおーん。』（犬より。）
+"""
+
+DOCUMENT6 = """
+わんわん。「にゃ？」(にゃー）わんわん．「わおーん。」（犬より。）
 """
 
 
@@ -48,4 +58,18 @@ def test_sentence_tokenize_with_combined():
     corpus = SentenceTokenizer()
     expect = ["わんわん。", "「にゃ？」(にゃー）わんわん。", "「わおーん。」（犬より。）"]
     result = corpus.tokenize(DOCUMENT4)
+    assert expect == result
+
+
+def test_sentence_tokenize_with_custom_patterns():
+    corpus = SentenceTokenizer(patterns=SentenceTokenizer.PATTERNS + [re.compile(r"『.*?』")])
+    expect = ["わんわん。", "「にゃ？」(にゃー）わんわん。", "『わおーん。』（犬より。）"]
+    result = corpus.tokenize(DOCUMENT5)
+    assert expect == result
+
+
+def test_sentence_tokenize_with_custom_period():
+    corpus = SentenceTokenizer(period="．")
+    expect = ["わんわん。「にゃ？」(にゃー）わんわん．", "「わおーん。」（犬より。）"]
+    result = corpus.tokenize(DOCUMENT6)
     assert expect == result


### PR DESCRIPTION
This PR introduces two parameters `patterns` and `period` to make sentence tokenization configurable.
If these parameters are not given by users, the behavior doesn't change from previous versions of konoha.

## Pattern

```python
tokenizer = SentenceTokenizer(
    patterns=SentenceTokenizer.PATTERNS + [re.compile(r"『.*?』")],
)

document = "わんわん。「にゃ？」(にゃー）わんわん。『わおーん。』（犬より。）"
expect = ["わんわん。", "「にゃ？」(にゃー）わんわん。", "『わおーん。』（犬より。）"]

result = corpus.tokenize(DOCUMENT5)
assert expect == result
```

## Period

```python
tokenizer = SentenceTokenizer(period="．")

document = "わんわん。「にゃ？」(にゃー）わんわん．「わおーん。」（犬より。）"
expect = ["わんわん。「にゃ？」(にゃー）わんわん．", "「わおーん。」（犬より。）"]

result = corpus.tokenize(DOCUMENT5)
assert expect == result
```

Thank you so much @hppRC for the insight!