### PR TITLE
Add workflow to publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,17 @@
+name: publish
+
+on:
+  release:
+    types:
+      - published
+
+jobs:
+  deploy:
+    runs-on: ubuntu-20.04
+    if: github.event_name == 'release'
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build and publish to pypi
+      uses: JRubics/poetry-publish@v1.9
+      with:
+        pypi_token: ${{ secrets.PYPI_TOKEN }}


### PR DESCRIPTION
This PR introduces a workflow to automatically publish the package using poetry-publish.
https://github.com/marketplace/actions/publish-python-poetry-package