### PR TITLE
Update natto-py

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.7, 3.8, 3.9]
 
     steps:
     - uses: actions/checkout@v1

--- a/poetry.lock
+++ b/poetry.lock
@@ -468,7 +468,7 @@ six = "*"
 
 [[package]]
 name = "natto-py"
-version = "0.9.2"
+version = "1.0.0"
 description = "A Tasty Python Binding with MeCab(FFI-based, no SWIG or compiler necessary)"
 category = "main"
 optional = true
@@ -1083,7 +1083,7 @@ sudachi = ["sudachipy", "sudachidict-core"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.6.1"
-content-hash = "5fcdf251047d3d9087c0cdffed69fbe3539a713a2cd8d2c14cbbdb64942b1cdb"
+content-hash = "5fd9bc67561d3bc94ee0dfc112b0bdcfa5b5526ba51370489ea68224c5689745"
 
 [metadata.files]
 alabaster = [
@@ -1486,22 +1486,31 @@ nagisa = [
     {file = "nagisa-0.2.7-cp27-cp27m-manylinux1_x86_64.whl", hash = "sha256:b009fbde4300dd37e688bc21c6de502645955728532907d1665dde4c8e71f6d2"},
     {file = "nagisa-0.2.7-cp27-cp27mu-manylinux1_i686.whl", hash = "sha256:271f9c747f4ffe00580babd06a4edc164dab1198857433750bca25f172f8438d"},
     {file = "nagisa-0.2.7-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:afa6673b846ebe0a5d9015bf78d1aeb82554b8cd023968b1ae8ecee2f46eb298"},
+    {file = "nagisa-0.2.7-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:ac5d0bd61d4f886a9f7fb963b7adccbc472f598d2665c500ffac71cb06d5c472"},
+    {file = "nagisa-0.2.7-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7277097425bdc6c980eeab3ddc9e3843a6b9204ef4c376d5e8e2e099f1c6b315"},
+    {file = "nagisa-0.2.7-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:85a466d3a0193d553cb6194df6267005c797c904ba25fc99040a9fe594bdbe62"},
+    {file = "nagisa-0.2.7-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:6fd1677e9f56e7ee56c0657aa3724baa317b7a70b14273717cab9f97e0a0f9ca"},
+    {file = "nagisa-0.2.7-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2ddcdf5eba1386eae88e764e80958a93db44f28ca245e8ba34ba1613834dd48a"},
     {file = "nagisa-0.2.7-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:b7537e3c4a14dc2decb5a3daa389a3c8d8fc079200fb4b56c079a66782fe5c1b"},
     {file = "nagisa-0.2.7-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:23aa8e5eadf2502410a23863e6347b5763c86cae01ed7600dd4a632306670bca"},
+    {file = "nagisa-0.2.7-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:fed2b06f422325c0be6887e682a33d2536bcda5f7b35970f2a815983019377dd"},
     {file = "nagisa-0.2.7-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:eb889e12d1f3a68fa7fb1440453aa9130c13244633ebd4f16b97d373dadbc122"},
     {file = "nagisa-0.2.7-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:07fa155ec5fcb80208d31bb6fd7039d6c2988c3b82c0cdba4baf60624e936c62"},
     {file = "nagisa-0.2.7-cp36-cp36m-win_amd64.whl", hash = "sha256:eb21e331064f9f8f3d9021761efc30ff94bb36b4ee7f0b9ce7a055c46abe93c0"},
+    {file = "nagisa-0.2.7-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:99671e1cebc20bbdb36f47dd164a888f3708b22b2bd4a153ec6298514c5b647d"},
     {file = "nagisa-0.2.7-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:2c70681c0dc6dc717f93dfb065a14916592a9c702752b2a2e31234dbb3f012f5"},
     {file = "nagisa-0.2.7-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:f4883c362440ec5594696e4c1f17831182d20cb845f2b080e838944d711c4c13"},
     {file = "nagisa-0.2.7-cp37-cp37m-win_amd64.whl", hash = "sha256:8b948f73d4884057eb2c20c70a9462823e00779fc35de14afd848467b91299c3"},
+    {file = "nagisa-0.2.7-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:caa869eb64c29d776123bcc706695e427d0da28a4208b63d115bf438f6b6ea8a"},
     {file = "nagisa-0.2.7-cp38-cp38-manylinux1_i686.whl", hash = "sha256:b03e4cd471c3a76aebd45c2bba38233f34b23c100d289837d08d664ccc38ad58"},
     {file = "nagisa-0.2.7-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:d59b25461e9643e463a6f6eacb8182e591e7f8904215c7b4e94ff77b722267c4"},
+    {file = "nagisa-0.2.7-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:b0d46c38a73574b6c3d638f95af664d464e0b17bc4b5b6bd73b74cc8b91cefc4"},
     {file = "nagisa-0.2.7-cp39-cp39-manylinux1_i686.whl", hash = "sha256:1cdc1e8f3149f5414d4572b122d794c0cd22f40dce67c8f4e53381edc34cd0ff"},
     {file = "nagisa-0.2.7-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:d409014216b1ce2984a988c3f7557aa0d82d7c6102a3fb6d3dba3f1909333d12"},
     {file = "nagisa-0.2.7.tar.gz", hash = "sha256:1654650efbc3424fee90ba0259701949bc00843fd2b83bb27a27dddd96f0fbdc"},
 ]
 natto-py = [
-    {file = "natto-py-0.9.2.tar.gz", hash = "sha256:f1538230fd2f96b916f95b8d9972e3fbd4f558573b8ef7e8b711394102c35191"},
+    {file = "natto-py-1.0.0.tar.gz", hash = "sha256:af9a5a5c58b4356d4cc9d7b6f2eee3b2eb334fb1a42096c16f6284c5e4fc090b"},
 ]
 numpy = [
     {file = "numpy-1.19.5-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:cc6bd4fd593cb261332568485e20a0712883cf631f6f5e8e86a52caa8b2b50ff"},
@@ -1741,6 +1750,8 @@ sentencepiece = [
     {file = "sentencepiece-0.1.96-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e9e9fe8094ca57549d801e9a2017ac5c24108bbf485ea4f8994a72e8e96ee135"},
     {file = "sentencepiece-0.1.96-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b77d27f59d515c43b61745b8173fbe7c7b3014b14b3702a75bf1793471e7def6"},
     {file = "sentencepiece-0.1.96-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1dac8c2ad02b5ebc1179c0a14cbc7d7c6f4fd73d4dd51820626402d0aefc974e"},
+    {file = "sentencepiece-0.1.96-cp310-cp310-win32.whl", hash = "sha256:3028699bdb2fb0230804f3b8a617fe3af22f5c5a56416419b31a7da5e7bf83bc"},
+    {file = "sentencepiece-0.1.96-cp310-cp310-win_amd64.whl", hash = "sha256:203443a7bd4295b6a3695787235abe0e77d4c369d7156a6b9a397c540a38bd27"},
     {file = "sentencepiece-0.1.96-cp35-cp35m-macosx_10_6_x86_64.whl", hash = "sha256:e8ec5bb6777e2060e1499750c50e1b69dca5a0f80f90f2c66656c5f3e5244593"},
     {file = "sentencepiece-0.1.96-cp36-cp36m-macosx_10_6_x86_64.whl", hash = "sha256:99ea2d9db19e63a2d17d5dc64f9ace83fb9308a735be05a1aaf98eb4b496fba7"},
     {file = "sentencepiece-0.1.96-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:aeb090ad462833df03af1debce4ae607a2766ef861f992003ad0c56d074ab805"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ python = "^3.6.1"
 importlib-metadata = "^4.0.0"
 overrides = {version = "^3.0.0"}
 janome = {version = "^0.3.10", optional = true}
-natto-py = {version = "^0.9.0", optional = true}
+natto-py = {version = "^1.0.0", optional = true}
 kytea = {version = "^0.1.4", optional = true}
 sentencepiece = {version = "^0.1.85", optional = true}
 sudachipy = {version = "0.4.9", optional = true}


### PR DESCRIPTION
Use natto-py >=1.0.0 in the konoha. Note that this PR also drops Python v3.6.