### PR TITLE
remove pydantic deprecation warning

### DIFF
--- a/src/konoha/api/v1/batch_tokenization.py
+++ b/src/konoha/api/v1/batch_tokenization.py
@@ -26,7 +26,7 @@ logger = logging.getLogger("uvicorn.app.konoha.api.v1.batch_tokenization")
 
 
 def generate_cache_key(params):
-    params = params.dict(exclude={"text", "texts"})
+    params = params.model_dump(exclude={"text", "texts"})
     return ".".join(f"{k}-{v}" for k, v in params.items())
 
 

--- a/src/konoha/api/v1/tokenization.py
+++ b/src/konoha/api/v1/tokenization.py
@@ -26,7 +26,7 @@ logger = logging.getLogger("uvicorn.app.konoha.api.v1.tokenization")
 
 
 def generate_cache_key(params):
-    params = params.dict(exclude={"text", "texts"})
+    params = params.model_dump(exclude={"text", "texts"})
     return ".".join(f"{k}-{v}" for k, v in params.items())
 
 


### PR DESCRIPTION
In pytest outputs, there are warnings like below.
I removed two `pydantic` deprecation warning by replacing `dict` with `model_dump`.
ref: https://docs.pydantic.dev/latest/concepts/serialization/#modelmodel_dump

```
=============================== warnings summary ===============================
tests/api/v1/test_batch_tokenization.py: 10 warnings
  /home/runner/work/konoha/konoha/src/konoha/api/v1/batch_tokenization.py:29: PydanticDeprecatedSince20: The `dict` method is deprecated; use `model_dump` instead. Deprecated in Pydantic V2.0 to be removed in V3.0. See Pydantic V2 Migration Guide at https://errors.pydantic.dev/2.11/migration/
    params = params.dict(exclude={"text", "texts"})

tests/api/v1/test_batch_tokenization.py::test_tokenization[tokenizer_params7]
  /home/runner/work/konoha/konoha/.venv/lib/python3.11/site-packages/nagisa/tagger.py:45: DeprecationWarning: invalid escape sequence '\('
    single_word_list = [w.replace('(', '\(').replace(')', '\)')

tests/api/v1/test_batch_tokenization.py::test_tokenization[tokenizer_params7]
  /home/runner/work/konoha/konoha/.venv/lib/python3.11/site-packages/nagisa/tagger.py:45: DeprecationWarning: invalid escape sequence '\)'
    single_word_list = [w.replace('(', '\(').replace(')', '\)')

tests/api/v1/test_tokenization.py: 11 warnings
  /home/runner/work/konoha/konoha/src/konoha/api/v1/tokenization.py:29: PydanticDeprecatedSince20: The `dict` method is deprecated; use `model_dump` instead. Deprecated in Pydantic V2.0 to be removed in V3.0. See Pydantic V2 Migration Guide at https://errors.pydantic.dev/2.11/migration/
    params = params.dict(exclude={"text", "texts"})

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
```